### PR TITLE
Option to translate "Nullable" props in C# to "optional" props in TS #15

### DIFF
--- a/src/Generator/IntellisenseProperty.cs
+++ b/src/Generator/IntellisenseProperty.cs
@@ -16,6 +16,8 @@ namespace TypeScriptDefinitionGenerator
 
         public string Name { get; set; }
 
+        public string NameWithOption { get { return (this.Type != null && this.Type.IsOptional) ? this.Name + "?" : this.Name; } }
+
         [SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods",
             Justification = "Unambiguous in this context.")]
         public IntellisenseType Type { get; set; }

--- a/src/Generator/IntellisenseType.cs
+++ b/src/Generator/IntellisenseType.cs
@@ -18,6 +18,8 @@ namespace TypeScriptDefinitionGenerator
 
         public bool IsDictionary { get; set; }
 
+        public bool IsOptional { get { return CodeName.EndsWith("?"); } }
+
         /// <summary>
         /// If this type is itself part of a source code file that has a .d.ts definitions file attached,
         /// this property will contain the full (namespace-qualified) client-side name of that type.

--- a/src/Generator/IntellisenseWriter.cs
+++ b/src/Generator/IntellisenseWriter.cs
@@ -132,7 +132,7 @@ namespace TypeScriptDefinitionGenerator
             foreach (var p in props)
             {
                 WriteTypeScriptComment(p, sb);
-                sb.AppendFormat("{0}\t{1}: ", prefix, CamelCasePropertyName(p.Name));
+                sb.AppendFormat("{0}\t{1}: ", prefix, CamelCasePropertyName(p.NameWithOption));
 
                 if (p.Type.IsKnownType) sb.Append(p.Type.TypeScriptName);
                 else


### PR DESCRIPTION
Added functionality for nullable props

`
    public class Child
    {
        public int? NumericValue { get; set; }
        public Nullable<int> NumericValue2 { get; set; }
        public string TextValue { get; set; }
    }

    public class ItemHeaderDto
    {
        public int? Id { get; set; }
        public string Name { get; set; } //
        public string Description { get; set; } //
    }
`

Generates

```
declare module server {
	interface child {
		NumericValue?: number;
		NumericValue2?: number;
		TextValue: string;
	}
	interface itemHeaderDto {
		Id?: number;
		Name: string;
		Description: string;
	}
}

```