### PR TITLE
Respect access level

### DIFF
--- a/src/Generator/IntellisenseObject.cs
+++ b/src/Generator/IntellisenseObject.cs
@@ -11,6 +11,7 @@ namespace TypeScriptDefinitionGenerator
         public string BaseName { get; set; }
         public string FullName { get; set; }
         public bool IsEnum { get; set; }
+        public bool IsPublic { get; set; }
         public string Summary { get; set; }
         public IList<IntellisenseProperty> Properties { get; private set; }
         public HashSet<string> References { get; private set; }

--- a/src/Generator/IntellisenseParser.cs
+++ b/src/Generator/IntellisenseParser.cs
@@ -112,6 +112,7 @@ namespace TypeScriptDefinitionGenerator
             {
                 Name = element.Name,
                 IsEnum = element.Kind == vsCMElement.vsCMElementEnum,
+                IsPublic = element.Access == vsCMAccess.vsCMAccessPublic,
                 FullName = element.FullName,
                 Namespace = GetNamespace(element),
                 Summary = GetSummary(element)
@@ -158,6 +159,7 @@ namespace TypeScriptDefinitionGenerator
             {
                 Namespace = ns,
                 Name = className,
+                IsPublic = cc.Access == vsCMAccess.vsCMAccessPublic,
                 BaseNamespace = baseNs,
                 BaseName = baseClassName,
                 FullName = cc.FullName,

--- a/src/Generator/IntellisenseWriter.cs
+++ b/src/Generator/IntellisenseWriter.cs
@@ -20,7 +20,8 @@ namespace TypeScriptDefinitionGenerator
             {
                 if (!Options.GlobalScope)
                 {
-                    sb.AppendFormat("declare module {0} {{\r\n", ns.Key);
+                    sb.AppendFormat(ns.First().IsPublic ? "export" : "declare");
+                    sb.AppendFormat(" module {0} {{\r\n", ns.Key);
                 }
 
                 foreach (IntellisenseObject io in ns)


### PR DESCRIPTION
Hi

A small change.
Use "export" and not to "declare" if original class/interface access is public.

Let me know what you think.
Greetings

CBke